### PR TITLE
Fix format mongod caused error parsing when sending to cwl

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -26,7 +26,7 @@
       awslogs_app_name: "{{service_name}}-mongod"
       awslogs_app_log_settings:
         - file: "/var/log/mongodb/mongod.log"
-          datetime_format: "%Y-%m-%dT%H:%M:%S.%f%z"
+          datetime_format: "%Y-%m-%dT%H:%M:%S.%F%z"
           group_name: "/tvlk/mongod/{{ service_name }}/mongod.log"
           time_zone: "UTC"
     - role: mongo-root-user


### PR DESCRIPTION
We checked that when agent fail to send log to cwl :

ssm-user@fprrem-mongod-03:/etc/awslogs/conf.d$ sudo tail -100f /var/log/awslogs/awslogs.log

` 2020-02-25 04:46:50,782 - cwlogs.push.publisher - INFO - 1243 - Thread-5 - Log group: /tvlk/global/amazon-ssm-agent.log, log stream: i-077310cf4eb0faa9d, queue size: 0, Publish batch: {'skipped_events_count': 0, 'first_event': {'timestamp': 1582606005106, 'start_position': 339500L, 'end_position': 339644L}, 'fallback_events_count': 1, 'last_event': {'timestamp': 1582606005106, 'start_position': 339500L, 'end_position': 339644L}, 'source_id': '28514756480b67648ca69f214a6be65f', 'num_of_events': 1, 'batch_size_in_bytes': 169}
2020-02-25 04:50:31,164 - cwlogs.push.reader - WARNING - 1243 - Thread-6 - Fall back to current time: {'timestamp': 1582606231164, 'start_position': 339644L, 'end_position': 339719L}, reason: timestamp could not be parsed from message.
2020-02-25 04:50:36,887 - cwlogs.push.publisher - INFO - 1243 - Thread-5 - Log group: /tvlk/global/amazon-ssm-agent.log, log stream: i-077310cf4eb0faa9d, queue size: 0, Publish batch: {'skipped_events_count': 0, 'first_event': {'timestamp': 1582606231164, 'start_position': 339644L, 'end_position': 339719L}, 'fallback_events_count': 1, 'last_event': {'timestamp': 1582606231164, 'start_position': 339644L, 'end_position': 339719L}, 'source_id': '28514756480b67648ca69f214a6be65f', 'num_of_events': 1, 'batch_size_in_bytes': 100}
2020-02-25 04:51:17,175 - cwlogs.push.reader - WARNING - 1243 - Thread-6 - Fall back to current time: {'timestamp': 1582606277175, 'start_position': 339719L, 'end_position': 339862L}, reason: timestamp could not be parsed from message.
2020-02-25 04:51:22,952 - cwlogs.push.publisher - INFO - 1243 - Thread-5 - Log group: /tvlk/global/amazon-ssm-agent.log, log stream: i-077310cf4eb0faa9d, queue size: 0, Publish batch: {'skipped_events_count': 0, 'first_event': {'timestamp': 1582606277175, 'start_position': 339719L, 'end_position': 339862L}, 'fallback_events_count': 1, 'last_event': {'timestamp': 1582606277175, 'start_position': 339719L, 'end_position': 339862L}, 'source_id': '28514756480b67648ca69f214a6be65f', 'num_of_events': 1, 'batch_size_in_bytes': 168}`

After update the config date format on prod via ssm :
ssm-user@fprrem-mongod-03:/var/snap/amazon-ssm-agent/1480$ cat /etc/awslogs/conf.d/fprrem-mongod.conf

[/var/log/mongodb/mongod.log]`
log_group_name = /tvlk/mongod/fprrem/mongod.log
log_stream_name = {instance_id}
datetime_format = %Y-%m-%dT%H:%M:%S.%F%z
file = /var/log/mongodb/mongod.log
time_zone = UTC

The error fail when sending the log to cwl got fixed
